### PR TITLE
feat: implement PomodoroSessionService with business rules

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,10 @@
-name: CI - Build & Test
+name: Java CI
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ develop ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ develop ]
 
 jobs:
   build:
@@ -12,14 +12,16 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout código
-        uses: actions/checkout@v3
+      - uses: actions/checkout@v3
 
-      - name: Setup Java 21
+      - name: Set up JDK 21
         uses: actions/setup-java@v3
         with:
           java-version: '21'
           distribution: 'temurin'
 
-      - name: Build com Maven
-        run: mvn clean install -DskipTests=false
+      - name: Build with Maven
+        run: mvn clean install -DskipTests
+
+      - name: Run unit tests
+        run: mvn test

--- a/pom.xml
+++ b/pom.xml
@@ -68,6 +68,11 @@
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,16 @@
 			<artifactId>junit-jupiter</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-core</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-junit-jupiter</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/com/luizdev/flowmodoro/application/service/PomodoroSessionService.java
+++ b/src/main/java/com/luizdev/flowmodoro/application/service/PomodoroSessionService.java
@@ -1,0 +1,47 @@
+package com.luizdev.flowmodoro.application.service;
+
+import com.luizdev.flowmodoro.domain.exception.PomodoroSessionNotFoundException;
+import com.luizdev.flowmodoro.domain.model.PomodoroSession;
+import com.luizdev.flowmodoro.domain.repository.PomodoroSessionRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.cglib.core.internal.Function;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class PomodoroSessionService {
+
+    private final PomodoroSessionRepository repository;
+
+    private void updateSession(UUID id, Function<PomodoroSession, PomodoroSession> transition) {
+        PomodoroSession session = getSession(id);
+        repository.save(transition.apply(session));
+    }
+
+
+    public UUID createSession(String theme, int duration, int breakTime, LocalDateTime schedulingDate)
+    {
+        PomodoroSession session = PomodoroSession.schedule(theme, duration, breakTime, schedulingDate);
+        return repository.save(session).getId();
+    }
+
+    public void startSession(UUID id) {
+        updateSession(id, PomodoroSession::start);
+    }
+
+    public void finishSession(UUID id) {
+        updateSession(id, PomodoroSession::finish);
+    }
+
+    public void cancelSession(UUID id) {
+        updateSession(id, PomodoroSession::cancel);
+    }
+
+    private PomodoroSession getSession(UUID id) {
+        return repository.findById(id)
+                .orElseThrow(() -> new PomodoroSessionNotFoundException(id));
+    }
+}

--- a/src/main/java/com/luizdev/flowmodoro/domain/exception/PomodoroSessionNotFoundException.java
+++ b/src/main/java/com/luizdev/flowmodoro/domain/exception/PomodoroSessionNotFoundException.java
@@ -1,0 +1,9 @@
+package com.luizdev.flowmodoro.domain.exception;
+
+import java.util.UUID;
+
+public class PomodoroSessionNotFoundException extends RuntimeException {
+    public PomodoroSessionNotFoundException(UUID id) {
+        super("Session not found with ID: " + id);
+    }
+}

--- a/src/main/java/com/luizdev/flowmodoro/domain/model/PomodoroSession.java
+++ b/src/main/java/com/luizdev/flowmodoro/domain/model/PomodoroSession.java
@@ -1,0 +1,69 @@
+package com.luizdev.flowmodoro.domain.model;
+
+import lombok.RequiredArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.AccessLevel;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Getter // Public Getters
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE) // Private Constructor
+@NoArgsConstructor(access = AccessLevel.PRIVATE, force = true) // No Args Private Constructor
+public class PomodoroSession {
+    private final UUID id;
+    private final String theme;
+    private final int durationMinutes;
+    private final int breakMinutes;
+    private final LocalDateTime dateScheduling;
+    private final PomodoroStatus status;
+
+    // Erro messages constants
+    private static final String INVALID_THEME_MSG = "Theme must not be null or empty";
+    private static final String INVALID_DURATION_MSG = "Duration must be between 15 and 120 minutes";
+    private static final String INVALID_BREAK_MSG = "Break must be between 5 and 30 minutes";
+    private static final String INVALID_SCHEDULE_DATE = "Date must not be in the past";
+    private static final int MIN_DURATION = 15;
+    private static final int MAX_DURATION = 120;
+    private static final int MIN_BREAK = 5;
+    private static final int MAX_BREAK = 30;
+
+    public static PomodoroSession schedule(String theme, int durationMinutes, int breakMinutes, LocalDateTime scheduleTime)
+    {
+        validateParameters(theme, durationMinutes, breakMinutes, scheduleTime);
+
+        return new PomodoroSession(UUID.randomUUID(), theme, durationMinutes, breakMinutes, determineScheduledTime(scheduleTime), determineStatus(scheduleTime));
+    }
+
+    public static void validateParameters(String theme, int durationMinutes, int breakMinutes, LocalDateTime dateScheduling)
+    {
+        if (theme == null || theme.isBlank() )
+        {
+            throw new IllegalArgumentException(INVALID_THEME_MSG);
+        }
+        if (durationMinutes < MIN_DURATION || durationMinutes > MAX_DURATION) {
+            throw new IllegalArgumentException(INVALID_DURATION_MSG);
+        }
+        if(breakMinutes < MIN_BREAK || breakMinutes > MAX_BREAK)
+        {
+            throw new IllegalArgumentException(INVALID_BREAK_MSG);
+        }
+        if (dateScheduling != null && dateScheduling.isBefore(LocalDateTime.now()))
+        {
+            throw new IllegalArgumentException(INVALID_SCHEDULE_DATE);
+        }
+    }
+
+    private static LocalDateTime determineScheduledTime(LocalDateTime proposedTime)
+    {
+        return proposedTime != null ? proposedTime : LocalDateTime.now();
+    }
+
+    private static PomodoroStatus determineStatus(LocalDateTime scheduledTime)
+    {
+        return scheduledTime != null ? PomodoroStatus.SCHEDULED : PomodoroStatus.IN_PROGRESS;
+    }
+
+
+}

--- a/src/main/java/com/luizdev/flowmodoro/domain/model/PomodoroSession.java
+++ b/src/main/java/com/luizdev/flowmodoro/domain/model/PomodoroSession.java
@@ -8,6 +8,11 @@ import lombok.AccessLevel;
 import java.time.LocalDateTime;
 import java.util.UUID;
 
+/**
+ * Domain model representing a Pomodoro session for study tracking.
+ * Encapsulates rules for creation and state transitions.
+ */
+
 @Getter // Public Getters
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE) // Private Constructor
 @NoArgsConstructor(access = AccessLevel.PRIVATE, force = true) // No Args Private Constructor
@@ -24,10 +29,26 @@ public class PomodoroSession {
     private static final String INVALID_DURATION_MSG = "Duration must be between 15 and 120 minutes";
     private static final String INVALID_BREAK_MSG = "Break must be between 5 and 30 minutes";
     private static final String INVALID_SCHEDULE_DATE = "Date must not be in the past";
+    private static final String INVALID_SCHEDULE_START_STATUS = "Only Scheduled sessions can be started";
+    private static final String INVALID_SCHEDULE_FINISH_STATUS = "Only in progress sessions can be finished";
+    private static final String INVALID_SCHEDULE_CANCEL_STATUS = "Only scheduled or in progress sessions can be canceled";
     private static final int MIN_DURATION = 15;
     private static final int MAX_DURATION = 120;
     private static final int MIN_BREAK = 5;
     private static final int MAX_BREAK = 30;
+
+    /**
+     * Creates a new Pomodoro session with validation rules.
+     * If a scheduling date is provided, the session will be marked as SCHEDULED.
+     * Otherwise, the session will start immediately (IN_PROGRESS).
+     *
+     * @param theme            The study theme (non-null, non-empty)
+     * @param durationMinutes  Study time in minutes (15 to 120)
+     * @param breakMinutes     Break time in minutes (5 to 30)
+     * @param scheduleTime     Optional scheduling date (must not be in the past)
+     * @return a new PomodoroSession instance
+     * @throws IllegalArgumentException if any parameter is invalid
+     */
 
     public static PomodoroSession schedule(String theme, int durationMinutes, int breakMinutes, LocalDateTime scheduleTime)
     {
@@ -65,5 +86,25 @@ public class PomodoroSession {
         return scheduledTime != null ? PomodoroStatus.SCHEDULED : PomodoroStatus.IN_PROGRESS;
     }
 
+    // Start session (change status)
+    public PomodoroSession start()
+    {
+        if (this.status != PomodoroStatus.SCHEDULED) throw new IllegalArgumentException(INVALID_SCHEDULE_START_STATUS);
+        return new PomodoroSession(this.id, this.theme, this.durationMinutes, this.breakMinutes, this.dateScheduling, PomodoroStatus.IN_PROGRESS);
+    }
+
+    // Finish Session
+    public PomodoroSession finish()
+    {
+        if (this.status != PomodoroStatus.IN_PROGRESS) throw new IllegalArgumentException(INVALID_SCHEDULE_FINISH_STATUS);
+        return new PomodoroSession(this.id, this.theme, this.durationMinutes, this.breakMinutes, this.dateScheduling, PomodoroStatus.FINISHED);
+    }
+
+    // Cancel Session
+    public PomodoroSession cancel()
+    {
+        if (this.status != PomodoroStatus.IN_PROGRESS && this.status != PomodoroStatus.SCHEDULED) throw new IllegalArgumentException(INVALID_SCHEDULE_CANCEL_STATUS);
+        return new PomodoroSession(this.id, this.theme, this.durationMinutes, this.breakMinutes, this.dateScheduling, PomodoroStatus.CANCELED);
+    }
 
 }

--- a/src/main/java/com/luizdev/flowmodoro/domain/model/PomodoroStatus.java
+++ b/src/main/java/com/luizdev/flowmodoro/domain/model/PomodoroStatus.java
@@ -1,0 +1,8 @@
+package com.luizdev.flowmodoro.domain.model;
+
+public enum PomodoroStatus {
+    SCHEDULED,
+    IN_PROGRESS,
+    FINISHED,
+    CANCELED
+}

--- a/src/main/java/com/luizdev/flowmodoro/domain/model/PomodoroStatus.java
+++ b/src/main/java/com/luizdev/flowmodoro/domain/model/PomodoroStatus.java
@@ -1,8 +1,19 @@
 package com.luizdev.flowmodoro.domain.model;
 
+/**
+ * Represents the lifecycle status of a Pomodoro session.
+ */
+
 public enum PomodoroStatus {
+    /** Session is scheduled to start in the future */
     SCHEDULED,
+
+    /** Session is currently in progress */
     IN_PROGRESS,
+
+    /** Session has been successfully completed */
     FINISHED,
+
+    /** Session was manually cancelled before finishing */
     CANCELED
 }

--- a/src/main/java/com/luizdev/flowmodoro/domain/repository/PomodoroSessionRepository.java
+++ b/src/main/java/com/luizdev/flowmodoro/domain/repository/PomodoroSessionRepository.java
@@ -1,0 +1,12 @@
+package com.luizdev.flowmodoro.domain.repository;
+
+import com.luizdev.flowmodoro.domain.model.PomodoroSession;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface PomodoroSessionRepository {
+
+    PomodoroSession save(PomodoroSession session);
+    Optional<PomodoroSession> findById(UUID id);
+}

--- a/src/test/java/com/luizdev/flowmodoro/PomodoroSessionTest.java
+++ b/src/test/java/com/luizdev/flowmodoro/PomodoroSessionTest.java
@@ -1,4 +1,203 @@
 package com.luizdev.flowmodoro;
 
+import com.luizdev.flowmodoro.domain.model.PomodoroSession;
+import com.luizdev.flowmodoro.domain.model.PomodoroStatus;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
 public class PomodoroSessionTest {
+    @Test
+    void shouldCreateScheduledSessionSuccessfully()
+    {
+        String theme = "Spring Boot Study";
+        int durationMinutes = 120;
+        int breakMinutes = 30;
+        LocalDateTime dateScheduling = LocalDateTime.now().plusMinutes(20);
+
+        PomodoroSession session = PomodoroSession.schedule(theme, durationMinutes, breakMinutes, dateScheduling);
+
+        assertEquals(theme, session.getTheme());
+        assertEquals(durationMinutes, session.getDurationMinutes());
+        assertEquals(breakMinutes, session.getBreakMinutes());
+        assertEquals(dateScheduling, session.getDateScheduling());
+        assertEquals(PomodoroStatus.SCHEDULED, session.getStatus());
+
+    }
+
+    @Test
+    void shouldThrowExceptionWhenThemeIsBlank()
+    {
+        String theme = "";
+        int durationMinutes = 120;
+        int breakMinutes = 30;
+        LocalDateTime dateScheduling = LocalDateTime.now().plusMinutes(20);
+
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+            PomodoroSession.schedule(theme, durationMinutes, breakMinutes, dateScheduling);
+        });
+
+        assertEquals("Theme must not be null or empty", exception.getMessage());
+    }
+
+    @Test
+    void shouldThrowExceptionWhenThemeIsNull()
+    {
+        String theme = null;
+        int durationMinutes = 120;
+        int breakMinutes = 30;
+        LocalDateTime dateScheduling = LocalDateTime.now().plusMinutes(20);
+
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+            PomodoroSession.schedule(theme, durationMinutes, breakMinutes, dateScheduling);
+        });
+
+        assertEquals("Theme must not be null or empty", exception.getMessage());
+    }
+
+    @Test
+    void shouldThrowExceptionWhenDurationMinutesIsOutOfRange()
+    {
+        String theme = "Spring Boot Study";
+        int durationMinutes = 5;
+        int breakMinutes = 30;
+        LocalDateTime dateScheduling = LocalDateTime.now().plusMinutes(20);
+
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+            PomodoroSession.schedule(theme, durationMinutes, breakMinutes, dateScheduling);
+        });
+
+        assertEquals("Duration must be between 15 and 120 minutes", exception.getMessage());
+    }
+
+    @Test
+    void shouldThrowExceptionWhenBreakMinutesIsOutOfRange()
+    {
+        String theme = "Spring Boot Study";
+        int durationMinutes = 120;
+        int breakMinutes = 60;
+        LocalDateTime dateScheduling = LocalDateTime.now().plusMinutes(20);
+
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+            PomodoroSession.schedule(theme, durationMinutes, breakMinutes, dateScheduling);
+        });
+
+        assertEquals("Break must be between 5 and 30 minutes", exception.getMessage());
+    }
+
+    @Test
+    void shouldThrowExceptionWhenDateSchedulingIsInPast()
+    {
+        String theme = "Spring Boot Study";
+        int durationMinutes = 120;
+        int breakMinutes = 20;
+        LocalDateTime dateScheduling = LocalDateTime.now().minusDays(10);
+
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, () -> {
+            PomodoroSession.schedule(theme, durationMinutes, breakMinutes, dateScheduling);
+        });
+
+        assertEquals("Date must not be in the past", exception.getMessage());
+    }
+
+    @Test
+    void shouldStartScheduledSessionSuccessfully() {
+        PomodoroSession scheduledSession = PomodoroSession.schedule(
+                "Java Deep Dive",
+                50,
+                10,
+                LocalDateTime.now().plusMinutes(30)
+        );
+
+        PomodoroSession startedSession = scheduledSession.start();
+
+        assertEquals(PomodoroStatus.IN_PROGRESS, startedSession.getStatus());
+    }
+
+    @Test
+    void shouldThrowExceptionWhenStartingNonScheduledSession() {
+        PomodoroSession inProgressSession = PomodoroSession.schedule(
+                "Kotlin Playground",
+                25,
+                5,
+                null // sem data = IN_PROGRESS
+        );
+
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, inProgressSession::start);
+        assertEquals("Only Scheduled sessions can be started", exception.getMessage());
+    }
+
+    @Test
+    void shouldFinishInProgressSessionSuccessfully() {
+        PomodoroSession inProgressSession = PomodoroSession.schedule(
+                "Spring Docs",
+                40,
+                10,
+                null // IN_PROGRESS
+        );
+
+        PomodoroSession finishedSession = inProgressSession.finish();
+
+        assertEquals(PomodoroStatus.FINISHED, finishedSession.getStatus());
+    }
+
+    @Test
+    void shouldThrowExceptionWhenFinishingNonInProgressSession() {
+        PomodoroSession scheduledSession = PomodoroSession.schedule(
+                "Error handling",
+                30,
+                5,
+                LocalDateTime.now().plusMinutes(15) // SCHEDULED
+        );
+
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, scheduledSession::finish);
+        assertEquals("Only in progress sessions can be finished", exception.getMessage());
+    }
+
+    @Test
+    void shouldCancelScheduledSessionSuccessfully() {
+        PomodoroSession scheduledSession = PomodoroSession.schedule(
+                "TDD Flow",
+                25,
+                5,
+                LocalDateTime.now().plusMinutes(15)
+        );
+
+        PomodoroSession canceledSession = scheduledSession.cancel();
+
+        assertEquals(PomodoroStatus.CANCELED, canceledSession.getStatus());
+    }
+
+    @Test
+    void shouldCancelInProgressSessionSuccessfully() {
+        PomodoroSession inProgressSession = PomodoroSession.schedule(
+                "JUnit Advanced",
+                45,
+                15,
+                null
+        );
+
+        PomodoroSession canceledSession = inProgressSession.cancel();
+
+        assertEquals(PomodoroStatus.CANCELED, canceledSession.getStatus());
+    }
+
+    @Test
+    void shouldThrowExceptionWhenCancelingFinishedSession() {
+        PomodoroSession inProgressSession = PomodoroSession.schedule(
+                "Refactor and Clean Code",
+                40,
+                10,
+                null
+        );
+
+        PomodoroSession finishedSession = inProgressSession.finish();
+
+        IllegalArgumentException exception = assertThrows(IllegalArgumentException.class, finishedSession::cancel);
+        assertEquals("Only scheduled or in progress sessions can be canceled", exception.getMessage());
+    }
+
 }

--- a/src/test/java/com/luizdev/flowmodoro/PomodoroSessionTest.java
+++ b/src/test/java/com/luizdev/flowmodoro/PomodoroSessionTest.java
@@ -1,0 +1,4 @@
+package com.luizdev.flowmodoro;
+
+public class PomodoroSessionTest {
+}

--- a/src/test/java/com/luizdev/flowmodoro/application/service/PomodoroSessionServiceTest.java
+++ b/src/test/java/com/luizdev/flowmodoro/application/service/PomodoroSessionServiceTest.java
@@ -1,0 +1,90 @@
+package com.luizdev.flowmodoro.application.service;
+
+import com.luizdev.flowmodoro.domain.exception.PomodoroSessionNotFoundException;
+import com.luizdev.flowmodoro.domain.model.PomodoroSession;
+import com.luizdev.flowmodoro.domain.repository.PomodoroSessionRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.*;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+import static org.mockito.ArgumentMatchers.any;
+
+@ExtendWith(MockitoExtension.class)
+public class PomodoroSessionServiceTest {
+
+    @Mock
+    private PomodoroSessionRepository repository;
+
+    @InjectMocks
+    private PomodoroSessionService service;
+
+    private final UUID sessionId = UUID.randomUUID();
+    private PomodoroSession scheduledSession;
+
+    @BeforeEach
+    void setup() {
+        scheduledSession = PomodoroSession.schedule("Estudo de java", 60, 5, LocalDateTime.now().plusMinutes(10));
+    }
+
+    @Test
+    void shouldCreateSessionSuccessfully() {
+        when(repository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+        UUID result = service.createSession("Estudo Java", 25, 5, scheduledSession.getDateScheduling());
+
+        assertNotNull(result);
+        verify(repository).save(any());
+    }
+
+    @Test
+    void shouldStartSessionWhenScheduled() {
+        when(repository.findById(sessionId)).thenReturn(Optional.of(scheduledSession));
+        when(repository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+        assertDoesNotThrow(() -> service.startSession(sessionId));
+        verify(repository).save(argThat(session -> session.getStatus().name().equals("IN_PROGRESS")));
+    }
+
+    @Test
+    void shouldThrowExceptionWhenSessionNotFound() {
+        when(repository.findById(sessionId)).thenReturn(Optional.empty());
+
+        assertThrows(PomodoroSessionNotFoundException.class, () -> service.startSession(sessionId));
+    }
+
+    @Test
+    void shouldFinishSessionWhenInProgress() {
+        PomodoroSession inProgress = scheduledSession.start();
+        when(repository.findById(sessionId)).thenReturn(Optional.of(inProgress));
+        when(repository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+        assertDoesNotThrow(() -> service.finishSession(sessionId));
+        verify(repository).save(argThat(session -> session.getStatus().name().equals("FINISHED")));
+    }
+
+    @Test
+    void shouldCancelSessionWhenScheduled() {
+        when(repository.findById(sessionId)).thenReturn(Optional.of(scheduledSession));
+        when(repository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+        assertDoesNotThrow(() -> service.cancelSession(sessionId));
+        verify(repository).save(argThat(session -> session.getStatus().name().equals("CANCELED")));
+    }
+
+    @Test
+    void shouldThrowExceptionWhenFinishingNotStartedSession() {
+        when(repository.findById(sessionId)).thenReturn(Optional.of(scheduledSession));
+
+        assertThrows(IllegalArgumentException.class, () -> service.finishSession(sessionId));
+    }
+
+
+}


### PR DESCRIPTION
# feat: implement PomodoroSessionService with business rules

## 📘 Description

This feature adds the `PomodoroSessionService`, a use case orchestration layer responsible for handling study session operations based on domain rules. It acts as the application service in a clean architecture context.

## ✅ What’s Included

- Class `PomodoroSessionService` created under `application.service`
- Supports the following operations:
  - `createSession(...)`
  - `startSession(UUID)`
  - `finishSession(UUID)`
  - `cancelSession(UUID)`
- Delegates state transitions to the immutable domain model
- Integrates with the `PomodoroSessionRepository` interface
- Throws `PomodoroSessionNotFoundException` for missing sessions
- Internal `updateSession(...)` method to reduce repetition

## 🧠 Design Highlights

- Clean separation between domain and application layers
- Fully immutable model usage
- Ready for persistence and controller integration

## 🧪 Tests

Test coverage handled separately in: `feature/pomodoro-session-service-tests`

## ✅ Checklist

- [x] Core use cases implemented
- [x] Stateless and testable design
- [x] No infra dependencies
- [x] CI passing
