### PR TITLE
test: add unit tests for PomodoroSessionService

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,6 +73,16 @@
 			<artifactId>junit-jupiter</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-core</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-junit-jupiter</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/com/luizdev/flowmodoro/application/service/PomodoroSessionService.java
+++ b/src/main/java/com/luizdev/flowmodoro/application/service/PomodoroSessionService.java
@@ -1,0 +1,47 @@
+package com.luizdev.flowmodoro.application.service;
+
+import com.luizdev.flowmodoro.domain.exception.PomodoroSessionNotFoundException;
+import com.luizdev.flowmodoro.domain.model.PomodoroSession;
+import com.luizdev.flowmodoro.domain.repository.PomodoroSessionRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.cglib.core.internal.Function;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+public class PomodoroSessionService {
+
+    private final PomodoroSessionRepository repository;
+
+    private void updateSession(UUID id, Function<PomodoroSession, PomodoroSession> transition) {
+        PomodoroSession session = getSession(id);
+        repository.save(transition.apply(session));
+    }
+
+
+    public UUID createSession(String theme, int duration, int breakTime, LocalDateTime schedulingDate)
+    {
+        PomodoroSession session = PomodoroSession.schedule(theme, duration, breakTime, schedulingDate);
+        return repository.save(session).getId();
+    }
+
+    public void startSession(UUID id) {
+        updateSession(id, PomodoroSession::start);
+    }
+
+    public void finishSession(UUID id) {
+        updateSession(id, PomodoroSession::finish);
+    }
+
+    public void cancelSession(UUID id) {
+        updateSession(id, PomodoroSession::cancel);
+    }
+
+    private PomodoroSession getSession(UUID id) {
+        return repository.findById(id)
+                .orElseThrow(() -> new PomodoroSessionNotFoundException(id));
+    }
+}

--- a/src/main/java/com/luizdev/flowmodoro/domain/exception/PomodoroSessionNotFoundException.java
+++ b/src/main/java/com/luizdev/flowmodoro/domain/exception/PomodoroSessionNotFoundException.java
@@ -1,0 +1,9 @@
+package com.luizdev.flowmodoro.domain.exception;
+
+import java.util.UUID;
+
+public class PomodoroSessionNotFoundException extends RuntimeException {
+    public PomodoroSessionNotFoundException(UUID id) {
+        super("Session not found with ID: " + id);
+    }
+}

--- a/src/main/java/com/luizdev/flowmodoro/domain/repository/PomodoroSessionRepository.java
+++ b/src/main/java/com/luizdev/flowmodoro/domain/repository/PomodoroSessionRepository.java
@@ -1,0 +1,12 @@
+package com.luizdev.flowmodoro.domain.repository;
+
+import com.luizdev.flowmodoro.domain.model.PomodoroSession;
+
+import java.util.Optional;
+import java.util.UUID;
+
+public interface PomodoroSessionRepository {
+
+    PomodoroSession save(PomodoroSession session);
+    Optional<PomodoroSession> findById(UUID id);
+}

--- a/src/test/java/com/luizdev/flowmodoro/application/service/PomodoroSessionServiceTest.java
+++ b/src/test/java/com/luizdev/flowmodoro/application/service/PomodoroSessionServiceTest.java
@@ -1,0 +1,90 @@
+package com.luizdev.flowmodoro.application.service;
+
+import com.luizdev.flowmodoro.domain.exception.PomodoroSessionNotFoundException;
+import com.luizdev.flowmodoro.domain.model.PomodoroSession;
+import com.luizdev.flowmodoro.domain.repository.PomodoroSessionRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.*;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+import static org.mockito.ArgumentMatchers.any;
+
+@ExtendWith(MockitoExtension.class)
+public class PomodoroSessionServiceTest {
+
+    @Mock
+    private PomodoroSessionRepository repository;
+
+    @InjectMocks
+    private PomodoroSessionService service;
+
+    private final UUID sessionId = UUID.randomUUID();
+    private PomodoroSession scheduledSession;
+
+    @BeforeEach
+    void setup() {
+        scheduledSession = PomodoroSession.schedule("Estudo de java", 60, 5, LocalDateTime.now().plusMinutes(10));
+    }
+
+    @Test
+    void shouldCreateSessionSuccessfully() {
+        when(repository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+        UUID result = service.createSession("Estudo Java", 25, 5, scheduledSession.getDateScheduling());
+
+        assertNotNull(result);
+        verify(repository).save(any());
+    }
+
+    @Test
+    void shouldStartSessionWhenScheduled() {
+        when(repository.findById(sessionId)).thenReturn(Optional.of(scheduledSession));
+        when(repository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+        assertDoesNotThrow(() -> service.startSession(sessionId));
+        verify(repository).save(argThat(session -> session.getStatus().name().equals("IN_PROGRESS")));
+    }
+
+    @Test
+    void shouldThrowExceptionWhenSessionNotFound() {
+        when(repository.findById(sessionId)).thenReturn(Optional.empty());
+
+        assertThrows(PomodoroSessionNotFoundException.class, () -> service.startSession(sessionId));
+    }
+
+    @Test
+    void shouldFinishSessionWhenInProgress() {
+        PomodoroSession inProgress = scheduledSession.start();
+        when(repository.findById(sessionId)).thenReturn(Optional.of(inProgress));
+        when(repository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+        assertDoesNotThrow(() -> service.finishSession(sessionId));
+        verify(repository).save(argThat(session -> session.getStatus().name().equals("FINISHED")));
+    }
+
+    @Test
+    void shouldCancelSessionWhenScheduled() {
+        when(repository.findById(sessionId)).thenReturn(Optional.of(scheduledSession));
+        when(repository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+        assertDoesNotThrow(() -> service.cancelSession(sessionId));
+        verify(repository).save(argThat(session -> session.getStatus().name().equals("CANCELED")));
+    }
+
+    @Test
+    void shouldThrowExceptionWhenFinishingNotStartedSession() {
+        when(repository.findById(sessionId)).thenReturn(Optional.of(scheduledSession));
+
+        assertThrows(IllegalArgumentException.class, () -> service.finishSession(sessionId));
+    }
+
+
+}


### PR DESCRIPTION
## 📘 Description

This feature provides unit test coverage for the `PomodoroSessionService`, ensuring its behavior aligns with domain rules using mocked repository interactions.

## ✅ What’s Included

- Unit tests using `JUnit 5` and `Mockito`
- Tested behaviors:
  - Successful session creation
  - Valid session start with status change
  - Exception thrown when session is not found
- Best practices applied:
  - `@ExtendWith(MockitoExtension.class)`
  - `@InjectMocks` and `@Mock`
  - `thenAnswer(...)` for realistic mocking
  - `argThat(...)` to validate saved state

## 🔍 Structure

- Located in `application.service.PomodoroSessionServiceTest`
- Fully isolated from infrastructure

## ✅ Checklist

- [x] Happy paths tested
- [x] Exception flow covered
- [x] Repository interactions verified
- [x] CI passing